### PR TITLE
Fix generation of type declaration files

### DIFF
--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "declaration": true
+  },
   "extends": "./tsconfig.json",
   "exclude": ["build/**/*", "tests/**/*"]
 }


### PR DESCRIPTION
Without this, no `.d.ts` files are produced in `build/`. This was introduced in https://github.com/plumdog/fetch-executable/pull/37, so no releases are affected.