### PR TITLE
Include kube-no-trouble

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,15 @@ Type: `Array<string>`
 Command line arguments to pass to the local executable to make it
 print its version.
 
+### `versionExecCaptureStderr`
+
+Required?: no, defaults capturing stdout
+
+Type: `boolean`
+
+If set to `true`, capture stderr from the executed command. Otherwise,
+captures stdout.
+
 ### `versionExecPostProcess`
 
 Required?: no, defaults to no post processing. Only relevant if `version` is set.

--- a/executables.ts
+++ b/executables.ts
@@ -236,3 +236,23 @@ export const yq = async (targetPath: string, version: string, options?: Partial<
         ...(options ?? {}),
     });
 };
+
+export const kubent = async (targetPath: string, version: string, options?: Partial<FetchExecutableOptions>): Promise<void> => {
+    await fetchExecutable({
+        target: targetPath,
+        url: 'https://github.com/doitintl/kube-no-trouble/releases/download/{version}/kubent-{version}-{platform}-{arch!x64ToAmd64}.tar.gz',
+        version,
+        versionExecArgs: ['--version'],
+        versionExecCaptureStderr: true,
+        versionExecPostProcess: (execOutput: string): string => {
+            const matches = execOutput.match(/\d+\.\d+\.\d+/);
+            if (matches) {
+                return matches[0] ?? '';
+            }
+            throw new Error('Unexpect output from kubent --version');
+        },
+        pathInTar: 'kubent',
+        gzExtract: true,
+        ...(options ?? {}),
+    });
+};


### PR DESCRIPTION
As of version 0.6.0, kube-no-trouble includes a `--version` flag.