### PR TITLE
Fix to support kubectl 1.24

### DIFF
--- a/executables.ts
+++ b/executables.ts
@@ -7,11 +7,20 @@ export const kubectl = async (targetPath: string, version: string, options?: Par
         version,
         versionExecArgs: ['version', '--client=true', '--short'],
         versionExecPostProcess: (execOutput: string): string => {
+            const lines = execOutput.split('\n');
             const prefix = 'Client Version: v';
-            if (!execOutput.startsWith(prefix)) {
-                throw new Error('Unexpected output from kubectl version');
+            const clientVersionLines = lines.filter((line: string) => line.startsWith(prefix));
+            const clientVersionLine = clientVersionLines[0];
+
+            if (!clientVersionLine) {
+                throw new Error(`Unexpected output from kubectl version, no lines started with prefix: ${prefix}`);
             }
-            return execOutput.substring(prefix.length).trim();
+
+            if (clientVersionLines.length > 1) {
+                throw new Error(`Unexpected output from kubectl version, multiple lines started with prefix: ${prefix}`);
+            }
+
+            return clientVersionLine.substring(prefix.length).trim();
         },
         hashMethod: 'sha256',
         hashValueUrl: 'https://dl.k8s.io/v{version}/bin/{platform}/{arch!x64ToAmd64}/kubectl.sha256',


### PR DESCRIPTION
Because eg:
```
$ 2&>/dev/null kubectl version --short --client
Client Version: v1.24.10
Kustomize Version: v4.5.4
```
So just find the line that starts `Client Version: ` and check that.